### PR TITLE
1. clean subscribers on complete, and auto-unsubscribe on completed S…

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -6,6 +6,7 @@ export interface ISubscription {
 export interface IStateEmitterOptions {
     distinct?: boolean;
     cloneMergeObjectsOnNext?: boolean;
+    onComplete?: () => {};
 }
 export declare class StateEmitter<T> {
     private state;
@@ -16,6 +17,7 @@ export declare class StateEmitter<T> {
     private completed;
     private distinct;
     private cloneMergeObjectsOnNext;
+    private onComplete;
     constructor(state?: T, options?: IStateEmitterOptions);
     next(state: T): void;
     private notify();

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,6 +3,10 @@ export interface ISubscription {
     unsubscribe(): void;
     destroy(): void;
 }
+export interface IStateEmitterOptions {
+    distinct?: boolean;
+    cloneMergeObjectsOnNext?: boolean;
+}
 export declare class StateEmitter<T> {
     private state;
     private subscribersCounter;
@@ -10,7 +14,9 @@ export declare class StateEmitter<T> {
     private isSetOnce;
     private previousState;
     private completed;
-    constructor(state?: T);
+    private distinct;
+    private cloneMergeObjectsOnNext;
+    constructor(state?: T, options?: IStateEmitterOptions);
     next(state: T): void;
     private notify();
     reset(): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ var isPlainObject = require("lodash.isplainobject");
 var callback_stack_1 = require("./callback_stack");
 var emitterStack = new callback_stack_1.CallbackStack();
 var StateEmitter = (function () {
-    function StateEmitter(state) {
+    function StateEmitter(state, options) {
         this.state = state;
         this.subscribersCounter = 0;
         this.subscribers = {};
@@ -21,19 +21,23 @@ var StateEmitter = (function () {
         if (state !== undefined) {
             this.isSetOnce = true;
         }
+        this.distinct = (options && options.distinct !== undefined) ? options.distinct : true;
+        this.cloneMergeObjectsOnNext = (options && options.cloneMergeObjectsOnNext !== undefined) ? options.cloneMergeObjectsOnNext : true;
     }
     StateEmitter.prototype.next = function (state) {
         if (this.completed) {
             return;
         }
-        var arePlainObjects = isPlainObject(state) && isPlainObject(this.state);
-        var changed = arePlainObjects
-            ? !isEqual(this.state, state)
-            : this.state !== state;
-        if (!changed) {
-            return;
+        var arePlainObjects = (this.distinct || this.cloneMergeObjectsOnNext) && isPlainObject(state) && isPlainObject(this.state);
+        if (this.distinct) {
+            var changed = arePlainObjects
+                ? !isEqual(this.state, state)
+                : this.state !== state;
+            if (!changed) {
+                return;
+            }
         }
-        var newValue = arePlainObjects
+        var newValue = (this.cloneMergeObjectsOnNext && arePlainObjects)
             ? __assign({}, this.state, state)
             : state;
         this.previousState = this.state;
@@ -72,7 +76,11 @@ var StateEmitter = (function () {
             id: this.subscribersCounter,
             subscribed: true,
             next: function () {
-                if (_this.isSetOnce && subscriber.subscribed) {
+                var shouldCall = _this.isSetOnce && subscriber.subscribed;
+                if (_this.completed) {
+                    unsubscribe();
+                }
+                if (shouldCall) {
                     callback.call(context, _this.state, _this.previousState, subscription);
                 }
             }
@@ -97,6 +105,7 @@ var StateEmitter = (function () {
     };
     StateEmitter.prototype.complete = function () {
         this.completed = true;
+        this.subscribers = {};
     };
     StateEmitter.prototype.whenEqual = function (expectedState, callback) {
         return this.subscribe(function (state, previousState) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,9 @@ var StateEmitter = (function () {
         }
         this.distinct = (options && options.distinct !== undefined) ? options.distinct : true;
         this.cloneMergeObjectsOnNext = (options && options.cloneMergeObjectsOnNext !== undefined) ? options.cloneMergeObjectsOnNext : true;
+        if (options && options.onComplete) {
+            this.onComplete = options.onComplete;
+        }
     }
     StateEmitter.prototype.next = function (state) {
         if (this.completed) {
@@ -104,8 +107,15 @@ var StateEmitter = (function () {
         return this.previousState;
     };
     StateEmitter.prototype.complete = function () {
-        this.completed = true;
-        this.subscribers = {};
+        if (!this.completed) {
+            this.completed = true;
+            this.subscribers = {};
+            if (this.onComplete) {
+                var onComplete = this.onComplete;
+                delete this.onComplete;
+                onComplete.call(this);
+            }
+        }
     };
     StateEmitter.prototype.whenEqual = function (expectedState, callback) {
         return this.subscribe(function (state, previousState) {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,6 +22,7 @@ interface ISubscriber<T> {
 export interface IStateEmitterOptions {
     distinct?: boolean,
     cloneMergeObjectsOnNext?: boolean;
+    onComplete?: () => {};
 }
 
 export class StateEmitter<T> {
@@ -35,6 +36,7 @@ export class StateEmitter<T> {
 
     private distinct: boolean;
     private cloneMergeObjectsOnNext: boolean;
+    private onComplete: () => {};
 
     constructor(private state?: T, options?: IStateEmitterOptions) {
         if (state !== undefined) {
@@ -43,6 +45,10 @@ export class StateEmitter<T> {
      
         this.distinct = (options && options.distinct !== undefined) ? options.distinct : true;
         this.cloneMergeObjectsOnNext = (options && options.cloneMergeObjectsOnNext !== undefined) ? options.cloneMergeObjectsOnNext : true;
+
+        if (options && options.onComplete) {
+            this.onComplete = options.onComplete;
+        }
     }
 
     public next(state: T): void {
@@ -143,8 +149,17 @@ export class StateEmitter<T> {
     }
 
     public complete(): void {
-        this.completed = true;
-        this.subscribers = {};
+        if (!this.completed) {
+            this.completed = true;
+            this.subscribers = {};
+            
+            if (this.onComplete) {
+                const onComplete = this.onComplete;
+                delete this.onComplete;
+
+                onComplete.call(this);
+            }  
+        }
     }
 
     public whenEqual(expectedState: T,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,6 +19,11 @@ interface ISubscriber<T> {
     next: StateEmitterCallback<T>,
 }
 
+export interface IStateEmitterOptions {
+    distinct?: boolean,
+    cloneMergeObjectsOnNext?: boolean;
+}
+
 export class StateEmitter<T> {
     private subscribersCounter = 0;
     private subscribers: {
@@ -28,24 +33,35 @@ export class StateEmitter<T> {
     private previousState: T;
     private completed = false;
 
-    constructor(private state?: T) {
+    private distinct: boolean;
+    private cloneMergeObjectsOnNext: boolean;
+
+    constructor(private state?: T, options?: IStateEmitterOptions) {
         if (state !== undefined) {
             this.isSetOnce = true;
         }
+     
+        this.distinct = (options && options.distinct !== undefined) ? options.distinct : true;
+        this.cloneMergeObjectsOnNext = (options && options.cloneMergeObjectsOnNext !== undefined) ? options.cloneMergeObjectsOnNext : true;
     }
 
     public next(state: T): void {
         if (this.completed) {
             return;
         }
-        const arePlainObjects = isPlainObject(state) && isPlainObject(this.state);
-        const changed = arePlainObjects
-            ? !isEqual(this.state, state)
-            : this.state !== state;
-        if (!changed) {
-            return;
+
+        const arePlainObjects = (this.distinct || this.cloneMergeObjectsOnNext) && isPlainObject(state) && isPlainObject(this.state);
+
+        if (this.distinct) {
+            const changed = arePlainObjects
+                ? !isEqual(this.state, state)
+                : this.state !== state;
+            if (!changed) {
+                return;
+            }
         }
-        const newValue = arePlainObjects
+
+        const newValue = (this.cloneMergeObjectsOnNext && arePlainObjects)
             ? {
                 ... this.state as Object,
                 ... state as Object
@@ -91,7 +107,12 @@ export class StateEmitter<T> {
             id: this.subscribersCounter,
             subscribed: true,
             next: () => {
-                if (this.isSetOnce && subscriber.subscribed) {
+                const shouldCall = this.isSetOnce && subscriber.subscribed;
+                if (this.completed) {
+                    unsubscribe();
+                }
+
+                if (shouldCall) {
                     callback.call(context, this.state, this.previousState, subscription);
                 }
             }
@@ -123,6 +144,7 @@ export class StateEmitter<T> {
 
     public complete(): void {
         this.completed = true;
+        this.subscribers = {};
     }
 
     public whenEqual(expectedState: T,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "state-emitter",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Reactive emitter",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "state-emitter",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Reactive emitter",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,13 +1,39 @@
 import {StateEmitter} from "../lib";
 import test from 'ava';
 
-test('should emit new values once subscribed', (t) => {
-    const se = new StateEmitter<number>(0);
-    t.plan(1);
-    se.subscribe((x) => {
-        t.is(x, 0);
+test('should emit new values once subscribed, and should not emit unchanged values if distinct is not false', (t) => {
+    const allOptions = [undefined, {distinct: true}, {distinct: false}];
+    const callCounts = [1, 1, 2];
+
+    allOptions.forEach((options, idx) => {
+        const se = new StateEmitter<number>(0, options);
+        let callCount = 0;
+        se.subscribe((x) => {
+            t.is(x, 0);
+            callCount++;
+        });
+        se.next(0);
+        t.is(callCount, callCounts[idx]);
     });
-    se.next(0);
+});
+
+test('should emit merge object values by default, and dont merge those if cloneMergeObjectsOnNext=false', (t) => {
+    type IObj = {x?: boolean, y?: boolean}
+
+    const allOptions = [undefined, {cloneMergeObjectsOnNext: true}, {cloneMergeObjectsOnNext: false}];
+    const equalVals = [false, false, true];
+
+    allOptions.forEach((options, idx) => {
+        const objX = {x: true};
+        const objY = {y: true};
+
+        const se = new StateEmitter<IObj>(objX, options);
+        t.is(true, se.get() === objX);
+
+        se.next(objY);
+
+        t.is(se.get() === objY, equalVals[idx]);
+    });
 });
 
 test('should emit new values to 2 subscribers', (t) => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -36,6 +36,17 @@ test('should emit merge object values by default, and dont merge those if cloneM
     });
 });
 
+test('should call onComplete callback if present', (t) => {
+    let completeCount = 0;
+    const se = new StateEmitter<number>(0, {
+        onComplete: () => completeCount++
+    });
+    
+    se.complete();
+    se.complete();
+    t.is(1, completeCount);
+});
+
 test('should emit new values to 2 subscribers', (t) => {
     const se = new StateEmitter<number>(0);
     let counter = 0;


### PR DESCRIPTION
…tateEmitter

2. added options:
2.1 distinct: boolean (true by default - means dont call subscribers if new value is same as old value),
2.2 cloneMergeObjectsOnNext: boolean (true by default - means shallow-cloning new object value, and merge it with old value)
also tests updated